### PR TITLE
fix: add Dependabot bypass to CodeQL-Build and re-enable workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,8 +37,29 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      # For Dependabot PRs: validate that only dependency files changed and skip full analysis.
+      # This satisfies the required CodeQL-Build status check without running a full scan,
+      # since Dependabot only bumps dependency versions and introduces no new source code.
+      - name: Validate Dependabot dependency-only changes
+        if: github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "Dependabot PR detected — validating only dependency files changed"
+          changed_files=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files --paginate --jq '.[].filename')
+          echo "Changed files:"
+          echo "$changed_files"
+          non_dep=$(echo "$changed_files" | grep -v -E '^(package\.json|package-lock\.json)$' || true)
+          if [ -n "$non_dep" ]; then
+            echo "::error::Unexpected non-dependency files changed in Dependabot PR:"
+            echo "$non_dep"
+            exit 1
+          fi
+          echo "✅ Only dependency files changed — CodeQL analysis not required"
+
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
+        if: "!(github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]')"
         uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v3.29.5
         # Override language selection by uncommenting this and choosing your languages
         # with:
@@ -47,18 +68,9 @@ jobs:
       # Autobuild attempts to build any compiled languages (C/C++, C#, Go, or Java).
       # If this step fails, then you should remove it and run the build manually (see below).
       - name: Autobuild
+        if: "!(github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]')"
         uses: github/codeql-action/autobuild@c10b8064de6f491fea524254123dbe5e09572f13 # v3.29.5
 
-      # ℹ️ Command-line programs to run using the OS shell.
-      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-      # ✏️ If the Autobuild fails above, remove it and uncomment the following
-      #    three lines and modify them (or add more) to build your code if your
-      #    project uses a compiled language
-
-      #- run: |
-      #     make bootstrap
-      #     make release
-
       - name: Perform CodeQL Analysis
+        if: "!(github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]')"
         uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v3.29.5


### PR DESCRIPTION
## Summary

Two issues were found blocking Dependabot PRs from auto-merging via the `CodeQL-Build` required status check:

1. **The CodeQL workflow was disabled manually** — so `CodeQL-Build` never reported any status on any PR.
2. **Dependabot PRs need a bypass** — even with the workflow re-enabled, Dependabot-triggered PRs only bump dependency versions and introduce no new source code, so a full CodeQL scan isn't meaningful.

## Changes

### `codeql.yml`
- **Re-enabled** the workflow (was `disabled_manually`)
- Added a **Dependabot-specific path** to the `CodeQL-Build` job:
  - Gates on `github.event.pull_request.user.login == 'dependabot[bot]'` (not `github.actor`, which can be spoofed more easily)
  - Uses the **GitHub PR files API** (`gh api .../pulls/{n}/files`) to enumerate changed files — more reliable than `git diff` on shallow checkouts
  - Validates that **only** `package.json` / `package-lock.json` changed; fails the job if anything else was modified
  - Exits successfully without running CodeQL, satisfying the required `CodeQL-Build` check
- All three CodeQL steps (`init`, `autobuild`, `analyze`) are skipped for Dependabot PRs via `if:` conditions

## Related
- Fixes the 3 pending required checks blocking PR #260 (also updated ruleset check names: `unit-tests` → `Run unit tests`, `run-local-action` → `Run action from branch`)