### PR TITLE
fix: pin reusable workflow dependencies to SHA hashes

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   actionlint:
-    uses: devops-actions/.github/.github/workflows/actionlint.yml@main
+    uses: devops-actions/.github/.github/workflows/actionlint.yml@74252b0a9809b8ff09ffe9408d5f344651e507ab # main
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/actions-example-checker.yml
+++ b/.github/workflows/actions-example-checker.yml
@@ -7,6 +7,6 @@ permissions:
 
 jobs:
   validate-examples:
-    uses: devops-actions/.github/.github/workflows/actions-example-checker.yml@main
+    uses: devops-actions/.github/.github/workflows/actions-example-checker.yml@74252b0a9809b8ff09ffe9408d5f344651e507ab # main
     permissions:
       contents: read

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   dependency-review:
-    uses: devops-actions/.github/.github/workflows/dependency-review.yml@main
+    uses: devops-actions/.github/.github/workflows/dependency-review.yml@74252b0a9809b8ff09ffe9408d5f344651e507ab # main
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary

Addresses code scanning alerts #70, #76, #77 (Pinned-Dependencies rule).

Three workflow files were referencing reusable workflows from `devops-actions/.github` using `@main` (a mutable ref). This is flagged by the OpenSSF Scorecard as a supply chain security issue.

## Changes

Pin all three reusable workflow references to commit SHA `74252b0a9809b8ff09ffe9408d5f344651e507ab` (current HEAD of `main`) with a `# main` comment for readability:

- `.github/workflows/actionlint.yml`
- `.github/workflows/actions-example-checker.yml`
- `.github/workflows/dependency-review.yml`