### PR TITLE
fix(codeql): allow workflow files in Dependabot dependency-only check

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,7 +55,42 @@ jobs:
             echo "$non_dep"
             exit 1
           fi
-          echo "✅ Only dependency files changed — CodeQL analysis not required"
+          echo "✅ Only dependency files changed"
+
+          # For workflow files: additionally verify every changed line is only a `uses:` action ref update.
+          # This prevents a compromised Dependabot PR from sneaking in extra content inside workflow files.
+          changed_workflows=$(echo "$changed_files" | grep -E '^\.github/workflows/[^/]+\.ya?ml$' || true)
+          if [ -n "$changed_workflows" ]; then
+            echo "Verifying workflow file changes are action-ref updates only..."
+            fail=false
+            while IFS= read -r wf_file; do
+              echo "  Inspecting: $wf_file"
+              patch=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+                --paginate --jq ".[] | select(.filename == \"$wf_file\") | .patch // empty")
+              # Extract actual changed lines (+/-), skip file header lines (+++ / ---)
+              diff_lines=$(printf '%s\n' "$patch" | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' || true)
+              if [ -z "$diff_lines" ]; then
+                echo "    No content changes."
+                continue
+              fi
+              # Each changed line must be a `uses:` action reference (with optional SHA comment).
+              # Matches: `uses: owner/repo@ref`, `uses: owner/repo@sha # tag`, `uses: ./local-action`
+              bad=$(printf '%s\n' "$diff_lines" | \
+                grep -vE '^[+-]\s+(-\s+)?uses:\s+(\./[^ ]+|[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)@[a-zA-Z0-9._/:-]+(\s+#.*)?$' || true)
+              if [ -n "$bad" ]; then
+                echo "::error::Non-action-ref changes detected in $wf_file — manual review required:"
+                printf '%s\n' "$bad"
+                fail=true
+              else
+                echo "    ✅ Only action refs updated in $wf_file"
+              fi
+            done <<< "$changed_workflows"
+            if [ "$fail" = "true" ]; then
+              exit 1
+            fi
+          fi
+
+          echo "✅ All dependency changes validated — CodeQL analysis not required"
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,7 +49,7 @@ jobs:
           changed_files=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files --paginate --jq '.[].filename')
           echo "Changed files:"
           echo "$changed_files"
-          non_dep=$(echo "$changed_files" | grep -v -E '^(package\.json|package-lock\.json)$' || true)
+          non_dep=$(echo "$changed_files" | grep -v -E '^(package\.json|package-lock\.json|yarn\.lock|\.github/workflows/[^/]+\.ya?ml|\.github/dependabot\.yml)$' || true)
           if [ -n "$non_dep" ]; then
             echo "::error::Unexpected non-dependency files changed in Dependabot PR:"
             echo "$non_dep"


### PR DESCRIPTION
## Problem

The \CodeQL-Build\ check was failing on all Dependabot PRs that bump GitHub Actions versions (e.g. \ctions/checkout\, \step-security/harden-runner\, \github/codeql-action\).

The root cause: the 'Validate Dependabot dependency-only changes' step used a regex that only allowed \package.json\ and \package-lock.json\ as valid dependency files. Dependabot also modifies \.github/workflows/*.yml\ when bumping action versions — those files didn't match, so the check incorrectly flagged them as 'unexpected non-dependency changes' and failed.

## Fix

Expand the allowed file pattern to also accept:
- \.github/workflows/*.yml\ / \.yaml\ — GitHub Actions version bumps
- \.github/dependabot.yml\ — dependabot config changes
- \yarn.lock\ — yarn lockfile

This unblocks the 8 currently-failing dependabot PRs (#281–#288).