### PR TITLE
Fix Dependabot workflow guard regex to allow subpath action refs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -74,9 +74,10 @@ jobs:
                 continue
               fi
               # Each changed line must be a `uses:` action reference (with optional SHA comment).
-              # Matches: `uses: owner/repo@ref`, `uses: owner/repo@sha # tag`, `uses: ./local-action`
+              # Matches: `uses: owner/repo@ref`, `uses: owner/repo@sha # tag`, `uses: ./local-action`,
+              # and subpath actions like `uses: owner/repo/subpath@ref` (e.g. github/codeql-action/autobuild).
               bad=$(printf '%s\n' "$diff_lines" | \
-                grep -vE '^[+-]\s+(-\s+)?uses:\s+(\./[^ ]+|[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)@[a-zA-Z0-9._/:-]+(\s+#.*)?$' || true)
+                grep -vE '^[+-]\s+(-\s+)?uses:\s+(\./[^ ]+|[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+(/[a-zA-Z0-9._-]+)*)@[a-zA-Z0-9._/:-]+(\s+#.*)?$' || true)
               if [ -n "$bad" ]; then
                 echo "::error::Non-action-ref changes detected in $wf_file — manual review required:"
                 printf '%s\n' "$bad"


### PR DESCRIPTION
## Why

PR #301 (and its duplicate #308), which bump `github/codeql-action/autobuild`, were stuck failing the required `CodeQL-Build` check. The failure came from the Dependabot guard step in `.github/workflows/codeql.yml`, which validates that Dependabot-authored changes to workflow files only touch `uses:` action-ref lines.

## The bug

The guard's regex only allowed a single `owner/repo` segment before the `@ref`:
```
[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+@...
```
`github/codeql-action/autobuild` is a subpath action (the action lives in a subfolder of the repo) and has an extra `/autobuild` segment, so it never matched. The script flagged the change as `Non-action-ref changes detected` and failed the job, blocking a completely legitimate dependency bump.

## Fix

Extended the regex to allow zero or more additional `/segment` path components before the `@ref`, so both plain (`owner/repo@ref`) and subpath (`owner/repo/subpath@ref`) action references are accepted:
```
[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+(/[a-zA-Z0-9._-]+)*@...
```

Verified against sample diff lines (a subpath action bump like `codeql-action/autobuild`, a plain action bump, a local action, and a non-`uses:` line) to confirm only genuine non-action-ref changes are still flagged as bad.

Once merged, PR #301 and #308 can be rebased so their `CodeQL-Build` check passes.