### PR TITLE
chore: group github-actions dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,8 +19,16 @@ updates:
     directory: '.github/workflows/'
     schedule:
       interval: monthly
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: monthly
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds a \groups.github-actions\ entry (pattern \*\) to the github-actions ecosystem update(s) in dependabot.yml, so future action version bumps are batched into a single PR instead of one per action.